### PR TITLE
[Main] Category 컴포넌트 구현 완료 및 기타 추가 기능 구현

### DIFF
--- a/public/footerData.json
+++ b/public/footerData.json
@@ -1,0 +1,19 @@
+{
+  "footerLinks": [
+    {
+      "id": 1,
+      "text": "회사소개서",
+      "link": "https://ncnc-public.s3.ap-northeast-2.amazonaws.com/doublenc.pdf"
+    },
+    {
+      "id": 2,
+      "text": "사업/제휴 문의",
+      "link": "mailTo:contact@doublenc.com"
+    },
+    {
+      "id": 3,
+      "text": "회사소개서",
+      "link": "https://ncnc.io/privacy"
+    }
+  ]
+}

--- a/src/components/atoms/CategoryButton/index.tsx
+++ b/src/components/atoms/CategoryButton/index.tsx
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router';
+import { ICategoryDetailProps } from 'types';
+import * as S from './style';
+
+export const CategoryButton = ({ category }: { category: ICategoryDetailProps }) => {
+  const router = useRouter();
+  const { id, name, imageUrl } = category;
+
+  const routeCategoryPage = () => {
+    router.push({
+      pathname: `/categories/${id}`,
+    });
+  };
+
+  return (
+    <S.Wrapper onClick={routeCategoryPage}>
+      <img alt={`카테고리: ${name}`} src={imageUrl} data-test="category-image" />
+      <span data-test="category-name">{name}</span>
+    </S.Wrapper>
+  );
+};

--- a/src/components/atoms/CategoryButton/style.tsx
+++ b/src/components/atoms/CategoryButton/style.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 111px;
+  height: 111px;
+  border-radius: 5px;
+  background-color: #ffffff;
+  cursor: pointer;
+
+  img {
+    width: 36px;
+    height: 36px;
+    margin-bottom: 15px;
+  }
+
+  span {
+    font-size: 12px;
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,13 +1,15 @@
 // Atoms
 export { BrandButton } from 'components/atoms/BrandButton';
 export { Caret } from 'components/atoms/Caret';
-export { Cross } from 'components/atoms/Cross';
+export { CategoryButton } from 'components/atoms/CategoryButton';
 export { ContentsDivider } from 'components/atoms/ContentsDivider';
-export { ItemOption } from 'components/atoms/ItemOption';
-export { NumItems } from 'components/atoms/NumItems';
+export { Cross } from 'components/atoms/Cross';
 export { Item } from 'components/atoms/Item';
 export { ItemInfo } from 'components/atoms/ItemInfo';
+export { ItemOption } from 'components/atoms/ItemOption';
+export { NumItems } from 'components/atoms/NumItems';
 export { Pencil } from 'components/atoms/Pencil';
+
 // Molecules
 export { Accordion } from 'components/molecules/Accordion';
 export { BrandLists } from 'components/molecules/BrandLists';
@@ -16,10 +18,11 @@ export { ItemLists } from 'components/molecules/ItemLists';
 // Organisms
 export { CustomerServiceInfo } from 'components/organisms/CustomerServiceInfo';
 export { Faq } from 'components/organisms/Faq';
+export { ItemButton } from 'components/organisms/ItemButton';
+export { ItemWarning } from 'components/organisms/ItemWarning';
+export { MainCategory } from 'components/organisms/MainCategory';
 export { MainDiscount } from 'components/organisms/MainDiscount';
 export { MainFooter } from 'components/organisms/MainFooter';
 export { MenuSelector } from 'components/organisms/MenuSelector';
-export { SlideMenu } from 'components/organisms/SlideMenu';
-export { ItemWarning } from 'components/organisms/ItemWarning';
-export { ItemButton } from 'components/organisms/ItemButton';
 export { NavBar } from 'components/organisms/NavBar';
+export { SlideMenu } from 'components/organisms/SlideMenu';

--- a/src/components/organisms/MainCategory/index.tsx
+++ b/src/components/organisms/MainCategory/index.tsx
@@ -1,0 +1,13 @@
+import { ICategoryDetailProps } from 'types';
+import { CategoryButton } from 'components';
+import * as S from './style';
+
+export const MainCategory = ({ categoryList }: { categoryList: Array<ICategoryDetailProps> }) => {
+  return (
+    <S.Wrapper data-test="category-wrapper">
+      {categoryList.map((category) => (
+        <CategoryButton key={category.id} category={category} />
+      ))}
+    </S.Wrapper>
+  );
+};

--- a/src/components/organisms/MainCategory/style.tsx
+++ b/src/components/organisms/MainCategory/style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.section`
+  display: grid;
+  place-items: center;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+
+  width: 100%;
+  padding: 17px;
+`;

--- a/src/components/organisms/MainDiscount/index.tsx
+++ b/src/components/organisms/MainDiscount/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { IMenuProps } from 'types';
 import * as S from './style';
 
@@ -7,24 +8,36 @@ export const MainDiscount = ({ itemList }: { itemList: Array<IMenuProps> }) => {
       <span>놓치지 마세요</span>
       <h4>오늘의 땡처리콘!</h4>
 
-      {itemList.map((item) => (
-        <S.Card key={item.id}>
-          <div
-            className="card-image"
-            data-test="discount-image"
-            style={{ backgroundImage: `url(${item.imageUrl})` }}
-          />
-          <div className="card-info">
-            <span data-test="discount-brand">{item.conCategory2.name}</span>
-            <h6 data-test="discount-name">{item.name}</h6>
-            <span className="discount-rate" data-test="discount-rate">
-              {item.discountRate}%
-            </span>
-            <strong data-test="discount-price">{item.ncSellingPrice.toLocaleString()}원</strong>
-            <del data-test="original-price">{item.originalPrice.toLocaleString()}원</del>
-          </div>
-        </S.Card>
-      ))}
+      {itemList.map((item) => {
+        const router = useRouter();
+        const { id, name, originalPrice, ncSellingPrice, discountRate, imageUrl, conCategory2 } =
+          item;
+
+        const routeItemPage = () => {
+          router.push({
+            pathname: `/items/${id}`,
+          });
+        };
+
+        return (
+          <S.Card key={id} onClick={routeItemPage}>
+            <div
+              className="card-image"
+              data-test="discount-image"
+              style={{ backgroundImage: `url(${imageUrl})` }}
+            />
+            <div className="card-info">
+              <span data-test="discount-brand">{conCategory2.name}</span>
+              <h6 data-test="discount-name">{name}</h6>
+              <span className="discount-rate" data-test="discount-rate">
+                {discountRate}%
+              </span>
+              <strong data-test="discount-price">{ncSellingPrice.toLocaleString()}원</strong>
+              <del data-test="original-price">{originalPrice.toLocaleString()}원</del>
+            </div>
+          </S.Card>
+        );
+      })}
     </S.Wrapper>
   );
 };

--- a/src/components/organisms/MainDiscount/index.tsx
+++ b/src/components/organisms/MainDiscount/index.tsx
@@ -16,7 +16,7 @@ export const MainDiscount = ({ itemList }: { itemList: Array<IMenuProps> }) => {
           />
           <div className="card-info">
             <span data-test="discount-brand">{item.conCategory2.name}</span>
-            <h6 data-test="discount-item">{item.name}</h6>
+            <h6 data-test="discount-name">{item.name}</h6>
             <span className="discount-rate" data-test="discount-rate">
               {item.discountRate}%
             </span>

--- a/src/components/organisms/MainDiscount/style.tsx
+++ b/src/components/organisms/MainDiscount/style.tsx
@@ -31,6 +31,7 @@ export const Card = styled.article`
   border-top: 1px solid #eeeeee;
   padding: 17px;
   background-color: #ffffff;
+  cursor: pointer;
 
   .card-image {
     width: 80px;

--- a/src/components/organisms/MainFooter/index.tsx
+++ b/src/components/organisms/MainFooter/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Caret } from 'components';
+import { footerLinks } from '../../../../public/footerData.json';
 import * as S from './style';
 
 export const MainFooter = () => {
@@ -10,11 +11,22 @@ export const MainFooter = () => {
 
   return (
     <S.Wrapper data-test="footer-wrapper">
+      <nav>
+        {footerLinks.map((data) => {
+          const { id, text, link } = data;
+
+          return (
+            <a key={id} href={link} target="_blank" rel="noreferrer">
+              {text}
+            </a>
+          );
+        })}
+      </nav>
+
       <button type="button" data-test="footer-toggle" onClick={toggleFooterInfo}>
         <h5>(주) 더블엔씨</h5>
         <Caret direction={isFooterInfoShown ? 'up' : 'down'} />
       </button>
-
       <p data-test="footer-info" className={isFooterInfoShown ? '' : 'hide'}>
         대표 : 박진희 <span>|</span> 이메일 : cs@doublenc.com
         <br />

--- a/src/components/organisms/MainFooter/style.tsx
+++ b/src/components/organisms/MainFooter/style.tsx
@@ -7,6 +7,19 @@ export const Wrapper = styled.footer`
 
   border-top: 1px solid #eeeeee;
   padding: 20px;
+  font-family: Apple SD Gothic Neo;
+  font-style: normal;
+  line-height: 1.15;
+
+  nav a {
+    display: block;
+    padding: 5px;
+
+    color: #888888;
+    font-size: 12px;
+    font-weight: 300;
+    cursor: pointer;
+  }
 
   button {
     display: flex;
@@ -19,7 +32,6 @@ export const Wrapper = styled.footer`
     color: #333333;
     font-size: 16px;
     font-weight: 500;
-    line-height: 1.15;
     cursor: pointer;
 
     svg {
@@ -30,7 +42,7 @@ export const Wrapper = styled.footer`
   }
 
   p {
-    color: #666666;
+    color: #999999;
     font-size: 11px;
     line-height: 1.7;
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { getCategoryList, getItemList } from 'utils';
 import { ICategoryDetailProps, IMenuProps } from 'types';
-import { NavBar, Caret, MainDiscount, MainFooter } from 'components';
+import { NavBar, Caret, MainCategory, MainDiscount, MainFooter } from 'components';
 
 export const Button = styled.button`
   display: flex;
@@ -44,9 +44,8 @@ const Home: NextPage = ({
         <img alt="" src="/images/main-carousel-1.png" style={{ height: '141px' }} />
       </section>
 
-      <section data-test="main-category" />
-
-      <MainDiscount itemList={itemList} />
+      <MainCategory data-test="main-category" categoryList={categoryList} />
+      <MainDiscount data-test="main-discount" itemList={itemList} />
       <MainFooter data-test="main-footer" />
     </>
   );


### PR DESCRIPTION
## 구현 화면
<img width="400" alt="week3_14" src="https://user-images.githubusercontent.com/72926450/154160480-b12f1883-b6e3-4769-819a-42975f333d09.png"> <img width="400" alt="week3_15" src="https://user-images.githubusercontent.com/72926450/154160464-79db42c4-10de-419e-91db-5ddcb7fd2265.png">

- 왼쪽 화면에서 API에 준비되어 있는 **'카페' 카테고리 카드를 클릭한 경우, 오른쪽 화면처럼 해당 카테고리 페이지로 라우팅 되는 기능이 구현되어 있습니다.** (`/categories/:id`)
- 마찬가지로, 왼쪽 화면에서 API에 준비되어 있는 **'땡처리콘' 상품 카드를 클릭한 경우, 해당 상품의 상세 페이지로 라우팅 되는 기능이 구현되어 있습니다.** (`/items/:id`) _(※ 구현 화면 생략)_

## 구현 범위

### 주요 구현 사항
- [x] API Call에 의해 수신한 대분류 목록을 리스트 렌더링 하는 **`MainCategory` 컴포넌트의 기능 구현 완료** (※ 참고: `BrandLists`)
- [x] 또한, `MainCategory` 컴포넌트의 하위 컴포넌트인 **`CategoryButton` 컴포넌트의 기능 구현 완료** (※ 참고: `BrandButton`)
- [x] `MainDiscount` 컴포넌트와 `MainFooter` 컴포넌트에 각각 라우팅 또는 링크 기능 추가 _(※ 자세한 내용은 커밋 내용 참고)_

### 기타 구현 사항
- [x] Cypress를 활용한 E2E Testing 구현에 대비하여 핵심 요구사항이 될 요소들에 `data-test` 속성 부여 및 속성명 컨벤션 통일